### PR TITLE
Portable PDB v1.0

### DIFF
--- a/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
+++ b/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
@@ -144,7 +144,7 @@
     <Compile Include="System\Reflection\Metadata\PortablePdb\LocalScope.cs" />
     <Compile Include="System\Reflection\Metadata\PortablePdb\LocalVariable.cs" />
     <Compile Include="System\Reflection\Metadata\PortablePdb\LocalVariableAttributes.cs" />
-    <Compile Include="System\Reflection\Metadata\PortablePdb\MethodBody.cs" />
+    <Compile Include="System\Reflection\Metadata\PortablePdb\MethodDebugInformation.cs" />
     <Compile Include="System\Reflection\Metadata\PortablePdb\SequencePoint.cs" />
     <Compile Include="System\Reflection\Metadata\PortablePdb\SequencePointBlobReader.cs" />
     <Compile Include="System\Reflection\Metadata\PortablePdb\Tables.Debug.cs" />

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/MetadataReaderExtensions.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/MetadataReaderExtensions.cs
@@ -94,7 +94,7 @@ namespace System.Reflection.Metadata.Ecma335
 
                 // debug tables
                 case TableIndex.Document: return reader.DocumentTable.RowSize;
-                case TableIndex.MethodBody: return reader.MethodBodyTable.RowSize;
+                case TableIndex.MethodDebugInformation: return reader.MethodDebugInformationTable.RowSize;
                 case TableIndex.LocalScope: return reader.LocalScopeTable.RowSize;
                 case TableIndex.LocalVariable: return reader.LocalVariableTable.RowSize;
                 case TableIndex.LocalConstant: return reader.LocalConstantTable.RowSize;
@@ -176,7 +176,7 @@ namespace System.Reflection.Metadata.Ecma335
 
                 // debug tables
                 case TableIndex.Document: return reader.DocumentTable.Block;
-                case TableIndex.MethodBody: return reader.MethodBodyTable.Block;
+                case TableIndex.MethodDebugInformation: return reader.MethodDebugInformationTable.Block;
                 case TableIndex.LocalScope: return reader.LocalScopeTable.Block;
                 case TableIndex.LocalVariable: return reader.LocalVariableTable.Block;
                 case TableIndex.LocalConstant: return reader.LocalConstantTable.Block;

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/TableIndex.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/TableIndex.cs
@@ -53,7 +53,7 @@ namespace System.Reflection.Metadata.Ecma335
 
         // debug tables:
         Document = 0x30,
-        MethodBody = 0x31,
+        MethodDebugInformation = 0x31,
         LocalScope = 0x32,
         LocalVariable = 0x33,
         LocalConstant = 0x34,

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/HandleKind.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/HandleKind.cs
@@ -35,7 +35,7 @@ namespace System.Reflection.Metadata
 
         // Debug handles
         Document = (byte)HandleType.Document,
-        MethodBody = (byte)HandleType.MethodBody,
+        MethodDebugInformation = (byte)HandleType.MethodDebugInformation,
         LocalScope = (byte)HandleType.LocalScope,
         LocalConstant = (byte)HandleType.LocalConstant,
         ImportScope = (byte)HandleType.ImportScope,

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Handles.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Handles.cs
@@ -636,6 +636,18 @@ namespace System.Reflection.Metadata
         {
             return left._rowId != right._rowId;
         }
+
+        /// <summary>
+        /// Returns a handle to <see cref="MethodDebugInformation"/> corresponding to this handle.
+        /// </summary>
+        /// <remarks>
+        /// The resulting handle is only valid within the context of a <see cref="MetadataReader"/> open on the Portable PDB blob,
+        /// which in case of standalone PDB file is a different reader than the one containing this method definition.
+        /// </remarks>
+        public MethodDebugInformationHandle ToDebugInformationHandle()
+        {
+            return MethodDebugInformationHandle.FromRowId(_rowId);
+        }
     }
 
     public struct MethodImplementationHandle : IEquatable<MethodImplementationHandle>

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Internal/MetadataFlags.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Internal/MetadataFlags.cs
@@ -62,7 +62,7 @@ namespace System.Reflection.Metadata.Ecma335
         GenericParamConstraint = 1UL << TableIndex.GenericParamConstraint,
 
         Document = 1UL << TableIndex.Document,
-        MethodBody = 1UL << TableIndex.MethodBody,
+        MethodDebugInformation = 1UL << TableIndex.MethodDebugInformation,
         LocalScope = 1UL << TableIndex.LocalScope,
         LocalVariable = 1UL << TableIndex.LocalVariable,
         LocalConstant = 1UL << TableIndex.LocalConstant,
@@ -122,7 +122,7 @@ namespace System.Reflection.Metadata.Ecma335
 
         PortablePdb_TablesMask =
             Document
-          | MethodBody
+          | MethodDebugInformation
           | LocalScope
           | LocalVariable
           | LocalConstant
@@ -222,7 +222,7 @@ namespace System.Reflection.Metadata.Ecma335
 
         // debug tables:
         internal const uint Document = (uint)TableIndex.Document;
-        internal const uint MethodBody = (uint)TableIndex.MethodBody;
+        internal const uint MethodDebugInformation = (uint)TableIndex.MethodDebugInformation;
         internal const uint LocalScope = (uint)TableIndex.LocalScope;
         internal const uint LocalVariable = (uint)TableIndex.LocalVariable;
         internal const uint LocalConstant = (uint)TableIndex.LocalConstant;
@@ -310,7 +310,7 @@ namespace System.Reflection.Metadata.Ecma335
 
         // debug tables:
         internal const uint Document = HandleType.Document << RowIdBitCount;
-        internal const uint MethodBody = HandleType.MethodBody << RowIdBitCount;
+        internal const uint MethodDebugInformation = HandleType.MethodDebugInformation << RowIdBitCount;
         internal const uint LocalScope = HandleType.LocalScope << RowIdBitCount;
         internal const uint LocalVariable = HandleType.LocalVariable << RowIdBitCount;
         internal const uint LocalConstant = HandleType.LocalConstant << RowIdBitCount;

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReader.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReader.cs
@@ -1109,7 +1109,7 @@ namespace System.Reflection.Metadata
             get { return new DocumentHandleCollection(this); }
         }
 
-        public MethodDebugInformationHandleCollection MethodBodies
+        public MethodDebugInformationHandleCollection MethodDebugInformation
         {
             get { return new MethodDebugInformationHandleCollection(this); }
         }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReader.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReader.cs
@@ -418,7 +418,7 @@ namespace System.Reflection.Metadata
 
         // debug tables
         internal DocumentTableReader DocumentTable;
-        internal MethodBodyTableReader MethodBodyTable;
+        internal MethodDebugInformationTableReader MethodDebugInformationTable;
         internal LocalScopeTableReader LocalScopeTable;
         internal LocalVariableTableReader LocalVariableTable;
         internal LocalConstantTableReader LocalConstantTable;
@@ -741,8 +741,8 @@ namespace System.Reflection.Metadata
             this.DocumentTable = new DocumentTableReader(rowCounts[(int)TableIndex.Document], guidHeapRefSize, blobHeapRefSize, metadataTablesMemoryBlock, totalRequiredSize);
             totalRequiredSize += this.DocumentTable.Block.Length;
 
-            this.MethodBodyTable = new MethodBodyTableReader(rowCounts[(int)TableIndex.MethodBody], GetReferenceSize(rowCounts, TableIndex.Document), blobHeapRefSize, metadataTablesMemoryBlock, totalRequiredSize);
-            totalRequiredSize += this.MethodBodyTable.Block.Length;
+            this.MethodDebugInformationTable = new MethodDebugInformationTableReader(rowCounts[(int)TableIndex.MethodDebugInformation], GetReferenceSize(rowCounts, TableIndex.Document), blobHeapRefSize, metadataTablesMemoryBlock, totalRequiredSize);
+            totalRequiredSize += this.MethodDebugInformationTable.Block.Length;
 
             this.LocalScopeTable = new LocalScopeTableReader(rowCounts[(int)TableIndex.LocalScope], methodRefSizeCombined, GetReferenceSize(rowCounts, TableIndex.ImportScope), GetReferenceSize(rowCounts, TableIndex.LocalVariable), GetReferenceSize(rowCounts, TableIndex.LocalConstant), metadataTablesMemoryBlock, totalRequiredSize);
             totalRequiredSize += this.LocalScopeTable.Block.Length;
@@ -1109,9 +1109,9 @@ namespace System.Reflection.Metadata
             get { return new DocumentHandleCollection(this); }
         }
 
-        public MethodBodyHandleCollection MethodBodies
+        public MethodDebugInformationHandleCollection MethodBodies
         {
-            get { return new MethodBodyHandleCollection(this); }
+            get { return new MethodDebugInformationHandleCollection(this); }
         }
 
         public LocalScopeHandleCollection LocalScopes
@@ -1454,14 +1454,14 @@ namespace System.Reflection.Metadata
             return new Document(this, handle);
         }
 
-        public MethodBody GetMethodBody(MethodBodyHandle handle)
+        public MethodDebugInformation GetMethodDebugInformation(MethodDebugInformationHandle handle)
         {
-            return new MethodBody(this, handle);
+            return new MethodDebugInformation(this, handle);
         }
 
-        public MethodBody GetMethodBody(MethodDefinitionHandle handle)
+        public MethodDebugInformation GetMethodDebugInformation(MethodDefinitionHandle handle)
         {
-            return new MethodBody(this, MethodBodyHandle.FromRowId(handle.RowId));
+            return new MethodDebugInformation(this, MethodDebugInformationHandle.FromRowId(handle.RowId));
         }
 
         public LocalScope GetLocalScope(LocalScopeHandle handle)
@@ -1500,7 +1500,7 @@ namespace System.Reflection.Metadata
             return new LocalScopeHandleCollection(this, handle.RowId);
         }
 
-        public LocalScopeHandleCollection GetLocalScopes(MethodBodyHandle handle)
+        public LocalScopeHandleCollection GetLocalScopes(MethodDebugInformationHandle handle)
         {
             return new LocalScopeHandleCollection(this, handle.RowId);
         }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/DebugMetadataHeader.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/DebugMetadataHeader.cs
@@ -1,14 +1,19 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Immutable;
+using System.Diagnostics;
+
 namespace System.Reflection.Metadata
 {
     public sealed class DebugMetadataHeader
     {
+        public readonly ImmutableArray<byte> Id;
         public readonly MethodDefinitionHandle EntryPoint;
 
-        internal DebugMetadataHeader(MethodDefinitionHandle entryPoint)
+        internal DebugMetadataHeader(ImmutableArray<byte> id, MethodDefinitionHandle entryPoint)
         {
+            Id = id;
             EntryPoint = entryPoint;
         }
     }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/HandleCollections.Debug.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/HandleCollections.Debug.cs
@@ -107,20 +107,20 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct MethodBodyHandleCollection : IReadOnlyCollection<MethodBodyHandle>
+    public struct MethodDebugInformationHandleCollection : IReadOnlyCollection<MethodDebugInformationHandle>
     {
         private readonly MetadataReader _reader;
 
         private readonly int _firstRowId;
         private readonly int _lastRowId;
 
-        internal MethodBodyHandleCollection(MetadataReader reader)
+        internal MethodDebugInformationHandleCollection(MetadataReader reader)
         {
             Debug.Assert(reader != null);
             _reader = reader;
 
             _firstRowId = 1;
-            _lastRowId = reader.MethodBodyTable.NumberOfRows;
+            _lastRowId = reader.MethodDebugInformationTable.NumberOfRows;
         }
 
         public int Count
@@ -136,7 +136,7 @@ namespace System.Reflection.Metadata
             return new Enumerator(_reader, _firstRowId, _lastRowId);
         }
 
-        IEnumerator<MethodBodyHandle> IEnumerable<MethodBodyHandle>.GetEnumerator()
+        IEnumerator<MethodDebugInformationHandle> IEnumerable<MethodDebugInformationHandle>.GetEnumerator()
         {
             return GetEnumerator();
         }
@@ -146,7 +146,7 @@ namespace System.Reflection.Metadata
             return GetEnumerator();
         }
 
-        public struct Enumerator : IEnumerator<MethodBodyHandle>, IEnumerator
+        public struct Enumerator : IEnumerator<MethodDebugInformationHandle>, IEnumerator
         {
             private readonly MetadataReader _reader;
             private readonly int _lastRowId; // inclusive
@@ -165,12 +165,12 @@ namespace System.Reflection.Metadata
                 _currentRowId = firstRowId - 1;
             }
 
-            public MethodBodyHandle Current
+            public MethodDebugInformationHandle Current
             {
                 get
                 {
                     // PERF: keep this code small to enable inlining.
-                    return MethodBodyHandle.FromRowId((int)(_currentRowId & TokenTypeIds.RIDMask));
+                    return MethodDebugInformationHandle.FromRowId((int)(_currentRowId & TokenTypeIds.RIDMask));
                 }
             }
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/Handles.Debug.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/Handles.Debug.cs
@@ -89,51 +89,51 @@ namespace System.Reflection.Metadata
         }
     }
 
-    public struct MethodBodyHandle : IEquatable<MethodBodyHandle>
+    public struct MethodDebugInformationHandle : IEquatable<MethodDebugInformationHandle>
     {
-        private const uint tokenType = TokenTypeIds.MethodBody;
-        private const byte tokenTypeSmall = (byte)HandleType.MethodBody;
+        private const uint tokenType = TokenTypeIds.MethodDebugInformation;
+        private const byte tokenTypeSmall = (byte)HandleType.MethodDebugInformation;
         private readonly int _rowId;
 
-        private MethodBodyHandle(int rowId)
+        private MethodDebugInformationHandle(int rowId)
         {
             Debug.Assert(TokenTypeIds.IsValidRowId(rowId));
             _rowId = rowId;
         }
 
-        internal static MethodBodyHandle FromRowId(int rowId)
+        internal static MethodDebugInformationHandle FromRowId(int rowId)
         {
-            return new MethodBodyHandle(rowId);
+            return new MethodDebugInformationHandle(rowId);
         }
 
-        public static implicit operator Handle(MethodBodyHandle handle)
+        public static implicit operator Handle(MethodDebugInformationHandle handle)
         {
             return new Handle(tokenTypeSmall, handle._rowId);
         }
 
-        public static implicit operator EntityHandle(MethodBodyHandle handle)
+        public static implicit operator EntityHandle(MethodDebugInformationHandle handle)
         {
             return new EntityHandle((uint)(tokenType | handle._rowId));
         }
 
-        public static explicit operator MethodBodyHandle(Handle handle)
+        public static explicit operator MethodDebugInformationHandle(Handle handle)
         {
             if (handle.VType != tokenTypeSmall)
             {
                 Throw.InvalidCast();
             }
 
-            return new MethodBodyHandle(handle.RowId);
+            return new MethodDebugInformationHandle(handle.RowId);
         }
 
-        public static explicit operator MethodBodyHandle(EntityHandle handle)
+        public static explicit operator MethodDebugInformationHandle(EntityHandle handle)
         {
             if (handle.VType != tokenType)
             {
                 Throw.InvalidCast();
             }
 
-            return new MethodBodyHandle(handle.RowId);
+            return new MethodDebugInformationHandle(handle.RowId);
         }
 
         public bool IsNil
@@ -146,17 +146,17 @@ namespace System.Reflection.Metadata
 
         internal int RowId { get { return _rowId; } }
 
-        public static bool operator ==(MethodBodyHandle left, MethodBodyHandle right)
+        public static bool operator ==(MethodDebugInformationHandle left, MethodDebugInformationHandle right)
         {
             return left._rowId == right._rowId;
         }
 
         public override bool Equals(object obj)
         {
-            return obj is MethodBodyHandle && ((MethodBodyHandle)obj)._rowId == _rowId;
+            return obj is MethodDebugInformationHandle && ((MethodDebugInformationHandle)obj)._rowId == _rowId;
         }
 
-        public bool Equals(MethodBodyHandle other)
+        public bool Equals(MethodDebugInformationHandle other)
         {
             return _rowId == other._rowId;
         }
@@ -166,7 +166,7 @@ namespace System.Reflection.Metadata
             return _rowId.GetHashCode();
         }
 
-        public static bool operator !=(MethodBodyHandle left, MethodBodyHandle right)
+        public static bool operator !=(MethodDebugInformationHandle left, MethodDebugInformationHandle right)
         {
             return left._rowId != right._rowId;
         }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/Handles.Debug.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/Handles.Debug.cs
@@ -170,6 +170,18 @@ namespace System.Reflection.Metadata
         {
             return left._rowId != right._rowId;
         }
+
+        /// <summary>
+        /// Returns a handle to <see cref="MethodDefinition"/> corresponding to this handle.
+        /// </summary>
+        /// <remarks>
+        /// The resulting handle is only valid within the context of a <see cref="MetadataReader"/> open on the type system metadata blob,
+        /// which in case of standalone PDB file is a different reader than the one containing this method debug information.
+        /// </remarks>
+        public MethodDefinitionHandle ToDefinitionHandle()
+        {
+            return MethodDefinitionHandle.FromRowId(_rowId);
+        }
     }
 
     public struct LocalScopeHandle : IEquatable<LocalScopeHandle>

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/MethodBody.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/MethodBody.cs
@@ -38,6 +38,18 @@ namespace System.Reflection.Metadata
         }
 
         /// <summary>
+        /// The document containing the first sequence point of the method, 
+        /// or nil if the method doesn't have sequence points.
+        /// </summary>
+        public DocumentHandle Document
+        {
+            get
+            {
+                return _reader.MethodBodyTable.GetDocument(Handle);
+            }
+        }
+
+        /// <summary>
         /// Returns local signature handle.
         /// </summary>
         public StandaloneSignatureHandle LocalSignature
@@ -51,6 +63,14 @@ namespace System.Reflection.Metadata
 
                 return StandaloneSignatureHandle.FromRowId(_reader.GetBlobReader(SequencePoints).ReadCompressedInteger());
             }
+        }
+
+        /// <summary>
+        /// Returns a sequence points reader.
+        /// </summary>
+        public SequencePointBlobReader GetSequencePointsReader()
+        {
+            return new SequencePointBlobReader(_reader.BlobStream.GetMemoryBlock(SequencePoints), Document);
         }
 
         /// <summary>

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/MethodDebugInformation.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/MethodDebugInformation.cs
@@ -5,14 +5,14 @@ using System.Diagnostics;
 
 namespace System.Reflection.Metadata
 {
-    public struct MethodBody
+    public struct MethodDebugInformation
     {
         private readonly MetadataReader _reader;
 
         // Workaround: JIT doesn't generate good code for nested structures, so use RowId.
         private readonly int _rowId;
 
-        internal MethodBody(MetadataReader reader, MethodBodyHandle handle)
+        internal MethodDebugInformation(MetadataReader reader, MethodDebugInformationHandle handle)
         {
             Debug.Assert(reader != null);
             Debug.Assert(!handle.IsNil);
@@ -21,9 +21,9 @@ namespace System.Reflection.Metadata
             _rowId = handle.RowId;
         }
 
-        private MethodBodyHandle Handle
+        private MethodDebugInformationHandle Handle
         {
-            get { return MethodBodyHandle.FromRowId(_rowId); }
+            get { return MethodDebugInformationHandle.FromRowId(_rowId); }
         }
 
         /// <summary>
@@ -33,7 +33,7 @@ namespace System.Reflection.Metadata
         {
             get
             {
-                return _reader.MethodBodyTable.GetSequencePoints(Handle);
+                return _reader.MethodDebugInformationTable.GetSequencePoints(Handle);
             }
         }
 
@@ -45,7 +45,7 @@ namespace System.Reflection.Metadata
         {
             get
             {
-                return _reader.MethodBodyTable.GetDocument(Handle);
+                return _reader.MethodDebugInformationTable.GetDocument(Handle);
             }
         }
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/Tables.Debug.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/Tables.Debug.cs
@@ -64,7 +64,7 @@ namespace System.Reflection.Metadata.Ecma335
         }
     }
 
-    internal struct MethodBodyTableReader
+    internal struct MethodDebugInformationTableReader
     {
         internal readonly int NumberOfRows;
 
@@ -77,7 +77,7 @@ namespace System.Reflection.Metadata.Ecma335
         internal readonly int RowSize;
         internal readonly MemoryBlock Block;
 
-        internal MethodBodyTableReader(
+        internal MethodDebugInformationTableReader(
             int numberOfRows,
             int documentRefSize,
             int blobHeapRefSize,
@@ -94,13 +94,13 @@ namespace System.Reflection.Metadata.Ecma335
             Block = containingBlock.GetMemoryBlockAt(containingBlockOffset, RowSize * numberOfRows);
         }
 
-        internal DocumentHandle GetDocument(MethodBodyHandle handle)
+        internal DocumentHandle GetDocument(MethodDebugInformationHandle handle)
         {
             int rowOffset = (handle.RowId - 1) * RowSize;
             return DocumentHandle.FromRowId(Block.PeekReference(rowOffset + DocumentOffset, _isDocumentRefSmall));
         }
 
-        internal BlobHandle GetSequencePoints(MethodBodyHandle handle)
+        internal BlobHandle GetSequencePoints(MethodDebugInformationHandle handle)
         {
             int rowOffset = (handle.RowId - 1) * RowSize;
             return BlobHandle.FromOffset(Block.PeekHeapReference(rowOffset + _sequencePointsOffset, _isBlobHeapRefSizeSmall));

--- a/src/System.Reflection.Metadata/tests/Metadata/HandleTests.cs
+++ b/src/System.Reflection.Metadata/tests/Metadata/HandleTests.cs
@@ -588,5 +588,17 @@ namespace System.Reflection.Metadata.Tests
                 }
             }
         }
+
+        [Fact]
+        public void MethodDefToDebugInfo()
+        {
+            Assert.Equal(
+                MethodDefinitionHandle.FromRowId(123).ToDebugInformationHandle(), 
+                MethodDebugInformationHandle.FromRowId(123));
+
+            Assert.Equal(
+                MethodDebugInformationHandle.FromRowId(123).ToDefinitionHandle(),
+                MethodDefinitionHandle.FromRowId(123));
+        }
     }
 }

--- a/src/System.Reflection.Metadata/tests/Metadata/HandleTests.cs
+++ b/src/System.Reflection.Metadata/tests/Metadata/HandleTests.cs
@@ -57,7 +57,7 @@ namespace System.Reflection.Metadata.Tests
             assert(default(BlobHandle), HandleKind.Blob);
             assert(default(NamespaceDefinitionHandle), HandleKind.NamespaceDefinition);
             assert(default(DocumentHandle), HandleKind.Document);
-            assert(default(MethodBodyHandle), HandleKind.MethodBody);
+            assert(default(MethodDebugInformationHandle), HandleKind.MethodDebugInformation);
             assert(default(LocalScopeHandle), HandleKind.LocalScope);
             assert(default(LocalConstantHandle), HandleKind.LocalConstant);
             assert(default(ImportScopeHandle), HandleKind.ImportScope);


### PR DESCRIPTION
Finalizes Portable PDB v1.0:

1) Adds Document column to MethodBody table -- it stores the document of the first sequence point. Allows the consumer to construct Document to Method map w/o decoding all sequence points (which is potentially MBs of data)
2) Calculate PDB ID as a hash of the PDB content and store it to #Pdb stream.
3) Change version in headers to 1.0
